### PR TITLE
Pin docker-py version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 supervisor
-docker-py==1.8.0rc4
+docker-py==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 supervisor
-docker-py
+docker-py==1.8.0rc4


### PR DESCRIPTION
On Pythons with old setuptools:

```
docker-py-1.8.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-0UfS1V/docker-py-1.8.0/egg-dist-tmp-SawTst
error: Setup script exited with error in docker-py setup command: Invalid environment marker: python_version < "3"
```

Looks like the this could potentially resolve it, but I'm in favor of pinning at a version until then:
https://github.com/docker/docker-py/issues/1019

Could also consider requiring a `pip install -U setuptools` prior to installing supervisor-remote-logging.
